### PR TITLE
fix: check for explicitly set seo description and keywords metadata

### DIFF
--- a/cms/controllers/Render.php
+++ b/cms/controllers/Render.php
@@ -140,7 +140,7 @@ class Render extends Base
         }
 
         if ($oData->seo_keywords) {
-            $this->oMetaData->setKeywords(explode(',', $oData->seo_keywords));
+            $this->oMetaData->setKeywords(preg_split('/[,; ]/', $oData->seo_keywords));
         }
 
         if ($oData->seo_image_id) {

--- a/cms/controllers/Render.php
+++ b/cms/controllers/Render.php
@@ -136,11 +136,11 @@ class Render extends Base
         $this->oMetaData->setTitles([$oData->seo_title ?: $oData->title]);
 
         if ($oData->seo_description) {
-            $this->oMetaData->setDescription($oData->seo_description ?: $oData->description);
+            $this->oMetaData->setDescription($oData->seo_description);
         }
 
         if ($oData->seo_keywords) {
-            $this->oMetaData->setKeywords(explode(',', $oData->seo_keywords ?: $oData->keywords));
+            $this->oMetaData->setKeywords(explode(',', $oData->seo_keywords));
         }
 
         if ($oData->seo_image_id) {

--- a/cms/controllers/Render.php
+++ b/cms/controllers/Render.php
@@ -133,10 +133,15 @@ class Render extends Base
 
         // --------------------------------------------------------------------------
 
-        $this->oMetaData
-            ->setTitles([$oData->seo_title ?: $oData->title])
-            ->setDescription($oData->seo_description)
-            ->setKeywords(explode(',', $oData->seo_keywords));
+        $this->oMetaData->setTitles([$oData->seo_title ?: $oData->title]);
+
+        if ($oData->seo_description) {
+            $this->oMetaData->setDescription($oData->seo_description ?: $oData->description);
+        }
+
+        if ($oData->seo_keywords) {
+            $this->oMetaData->setKeywords(explode(',', $oData->seo_keywords ?: $oData->keywords));
+        }
 
         if ($oData->seo_image_id) {
             $this->oMetaData


### PR DESCRIPTION
What was happening
CMS pages Render class was overwriting the Base controller description and keywords even when none was set

What this does
Adds a conditional check to check that these are set before overwriting